### PR TITLE
Updates Container class to make instances overwrite-able.

### DIFF
--- a/lib/Container.php
+++ b/lib/Container.php
@@ -37,12 +37,10 @@ class Container implements InstanceProvider
         $abstracts = Arr::merge([$abstract], $abstracts);
 
         foreach ($abstracts as $abstractClass) {
-            if(!isset($this->bindings[$abstractClass])) {
-                $this->bindings[$abstractClass] = $concrete;
+            $this->bindings[$abstractClass] = $concrete;
 
-                // This ensures all bound abstracts will return the same instance
-                $this->instances[$abstractClass] = &$instance;
-            }
+            // This ensures all bound abstracts will return the same instance
+            $this->instances[$abstractClass] = &$instance;
         }
 
         return $this;


### PR DESCRIPTION
## Summary

This PR updates the container to make singleton instances overwrite-able.

In some situations, it is possible that the container needs to be able to overwrite instances that were previously defined in the container. This makes it possible to do so.

## Details

An immediate use-case for this is in WordPress, where you have control of the entire stack. In these cases it often makes sense to create a `mu-plugin` that sets up a "template" container, which has the core integrations that the container always needs in that context.

Then, themes and plugins built on that site can clone the templated container, and override anything that needs to be overridden on it. For example, maybe the system should use the PHPEngine by default, but the theme should use Twig.

mu-plugin:
```php
$container = new Container();
(new Bootstrapper(
    $container,
    new CoreInitializer(),
    new WordPressInitializer()
))->load();
```

theme:
```php
$themeContainer = clone $container;
(new Bootstrapper(
    $themeContainer,
    new ThemeInitializer() // Theme specific overrides
))->load();
```

theme:
```php
$pluginContainer = clone $container;
(new Bootstrapper(
    $pluginContainer ,
    new PluginInitializer() // Plugin specific overrides
))->load();
```